### PR TITLE
Fix pal position on firefox

### DIFF
--- a/style.css
+++ b/style.css
@@ -133,6 +133,7 @@
 .popup-styles p::after {
   content: url('https://sharty-themes.b-cdn.net/party-pal/images/pal.png');
   position: fixed;
+  transform-origin: top left;
   zoom: 17%;
   left: 105%;
   top: 90%;


### PR DESCRIPTION
Really simple change, fixes the pal image being incorrectly positioned on Firefox.